### PR TITLE
Run migrations under `mongoid:` namespace against db/mongoid/migrate/ [UNI-6162]

### DIFF
--- a/lib/mongoid_rails_migrations/active_record_ext/migrations.rb
+++ b/lib/mongoid_rails_migrations/active_record_ext/migrations.rb
@@ -229,7 +229,9 @@ module Mongoid #:nodoc
       end
 
       def migrations_path
-        @migrations_path ||= ['db/migrate']
+        # uniiverse fork: default to the dedicated Mongoid path, kept separate from the
+        # ActiveRecord migrations in db/migrate (still overridable, e.g. in tests).
+        @migrations_path ||= ['db/mongoid/migrate']
       end
 
       def get_all_versions

--- a/lib/mongoid_rails_migrations/mongoid_ext/railties/database.rake
+++ b/lib/mongoid_rails_migrations/mongoid_ext/railties/database.rake
@@ -1,12 +1,37 @@
-namespace :db do
-  if Rake::Task.task_defined?("db:drop")
-    Rake::Task["db:drop"].clear
+namespace :mongoid do
+  unless Rake::Task.task_defined?("mongoid:drop")
+    desc 'Drops all the collections for the database for the current Rails.env'
+    task :drop => :environment do
+      # Mongoid 7: Mongoid.master was removed; drop non-system collections via the default client.
+      Mongoid::Migration.connection.database.collections.each do |col|
+        col.drop unless col.name.start_with?('system.')
+      end
+    end
   end
 
-  desc 'Drops the database for the current Mongoid client'
-  task :drop => :environment do
-    # Unlike Mongoid's default, this implementation supports the MONGOID_CLIENT_NAME override
-    Mongoid::Migration.connection.database.drop
+  unless Rake::Task.task_defined?("mongoid:seed")
+    # if another ORM has defined mongoid:seed, don't run it twice.
+    desc 'Load the seed data from db/seeds.rb'
+    task :seed => :environment do
+      seed_file = File.join(Rails.application.root, 'db', 'seeds.rb')
+      load(seed_file) if File.exist?(seed_file)
+    end
+  end
+
+  unless Rake::Task.task_defined?("mongoid:setup")
+    desc 'Create the database, and initialize with the seed data'
+    task :setup => [ 'mongoid:create', 'mongoid:seed' ]
+  end
+
+  unless Rake::Task.task_defined?("mongoid:reseed")
+    desc 'Delete data and seed'
+    task :reseed => [ 'mongoid:drop', 'mongoid:seed' ]
+  end
+
+  unless Rake::Task.task_defined?("mongoid:create")
+    task :create => :environment do
+      # noop
+    end
   end
 
   desc 'Current database version'
@@ -14,7 +39,7 @@ namespace :db do
     puts Mongoid::Migrator.current_version.to_s
   end
 
-  desc "Migrate the database through scripts in db/migrate. Target specific version with VERSION=x. Turn off output with VERBOSE=false."
+  desc "Migrate the database through scripts in db/mongoid/migrate. Target specific version with VERSION=x. Turn off output with VERBOSE=false."
   task :migrate => :environment do
     Mongoid::Migration.verbose = ENV["VERBOSE"] ? ENV["VERBOSE"] == "true" : true
     Mongoid::Migrator.migrate(Mongoid::Migrator.migrations_path, ENV["VERSION"] ? ENV["VERSION"].to_i : nil)
@@ -24,17 +49,16 @@ namespace :db do
     desc 'Rollback the database one migration and re migrate up. If you want to rollback more than one step, define STEP=x. Target specific version with VERSION=x.'
     task :redo => :environment do
       if ENV["VERSION"]
-        Rake::Task["db:migrate:down"].invoke
-        Rake::Task["db:migrate:up"].invoke
+        Rake::Task["mongoid:migrate:down"].invoke
+        Rake::Task["mongoid:migrate:up"].invoke
       else
-        Rake::Task["db:rollback"].invoke
-        Rake::Task["db:migrate"].invoke
+        Rake::Task["mongoid:rollback"].invoke
+        Rake::Task["mongoid:migrate"].invoke
       end
     end
 
     desc 'Resets your database using your migrations for the current environment'
-    # should db:create be changed to db:setup? It makes more sense wanting to seed
-    task :reset => ["db:drop", "db:create", "db:migrate"]
+    task :reset => ["mongoid:drop", "mongoid:create", "mongoid:migrate"]
 
     desc 'Runs the "up" for a given migration VERSION.'
     task :up => :environment do
@@ -67,5 +91,17 @@ namespace :db do
     version = ENV["VERSION"] ? ENV["VERSION"].to_i : nil
     raise "VERSION is required" unless version
     Mongoid::Migrator.rollback_to(Mongoid::Migrator.migrations_path, version)
+  end
+
+  namespace :schema do
+    task :load do
+      # noop
+    end
+  end
+
+  namespace :test do
+    task :prepare do
+      # Stub out for MongoDB
+    end
   end
 end

--- a/lib/rails/generators/mongoid/migration/migration_generator.rb
+++ b/lib/rails/generators/mongoid/migration/migration_generator.rb
@@ -6,7 +6,7 @@ module Mongoid
       class_option :shards, type: :boolean, optional: true, desc: "Create migration in shards subfolder"
 
       def create_migration_file
-        destination_folder = "db/migrate"
+        destination_folder = "db/mongoid/migrate"
         if options.fetch(:shards, Config.shards_migration_as_default)
           destination_folder = "#{destination_folder}/shards"
           FileUtils.mkdir_p("#{Rails.root}/#{destination_folder}")

--- a/test/migration_test.rb
+++ b/test/migration_test.rb
@@ -4,9 +4,9 @@ module Mongoid
   class TestCase < Minitest::Test #:nodoc:
 
     def setup
-      invoke("db:drop")
+      invoke("mongoid:drop")
       with_env("MONGOID_CLIENT_NAME" => "shard1") do
-        invoke("db:drop")
+        invoke("mongoid:drop")
       end
     end
 
@@ -15,15 +15,15 @@ module Mongoid
     end
 
     def test_drop_works
-      assert_equal 0, Mongoid::Migrator.current_version, "db:drop should take us down to version 0"
+      assert_equal 0, Mongoid::Migrator.current_version, "mongoid:drop should take us down to version 0"
     end
 
     def test_migrations_path
-      assert_equal ["db/migrate"], Mongoid::Migrator.migrations_path
+      assert_equal ["db/mongoid/migrate"], Mongoid::Migrator.migrations_path
 
       Mongoid::Migrator.migrations_path += ["engines/my_engine/db/migrate"]
 
-      assert_equal ["db/migrate", "engines/my_engine/db/migrate"], Mongoid::Migrator.migrations_path
+      assert_equal ["db/mongoid/migrate", "engines/my_engine/db/migrate"], Mongoid::Migrator.migrations_path
     end
 
     def test_finds_migrations

--- a/test/tasks/down_task_test.rb
+++ b/test/tasks/down_task_test.rb
@@ -3,12 +3,12 @@ require_relative './task_test_base'
 module Mongoid
   class DownTaskTest < TaskTestBase
     def test_database_migrate_down_raise_without_version
-      assert_raises { invoke("db:migrate:down") }
+      assert_raises { invoke("mongoid:migrate:down") }
     end
 
     def test_database_migrate_down
       Mongoid::Migrator.migrations_path = [MIGRATIONS_ROOT + "/valid"]
-      invoke("db:migrate")
+      invoke("mongoid:migrate")
       assert_output(<<-EOF
 
 database: mongoid_test
@@ -19,9 +19,9 @@ database: mongoid_test
    up     20100513055502  AddSecondSurveySchema
    up     20100513063902  AddImprovementPlanSurveySchema
 EOF
-      ) { invoke("db:migrate:status") }
+      ) { invoke("mongoid:migrate:status") }
       with_env("VERSION" => "20100513055502") do
-        invoke("db:migrate:down")
+        invoke("mongoid:migrate:down")
       end
       assert_output(<<-EOF
 
@@ -33,14 +33,14 @@ database: mongoid_test
   down    20100513055502  AddSecondSurveySchema
    up     20100513063902  AddImprovementPlanSurveySchema
 EOF
-      ) { invoke("db:migrate:status") }
+      ) { invoke("mongoid:migrate:status") }
     end
 
     def test_multidatabase_migrate_down
       Mongoid::Migrator.migrations_path = [MIGRATIONS_ROOT + "/multi_shards"]
-      invoke("db:migrate")
+      invoke("mongoid:migrate")
       with_env("MONGOID_CLIENT_NAME" => "shard1") do
-        invoke("db:migrate")
+        invoke("mongoid:migrate")
       end
 
       output = <<-EOF
@@ -52,7 +52,7 @@ database: mongoid_test
    up     20210210125000  DefaultDatabaseMigration
    up     20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("mongoid:migrate:status") }
       output = <<-EOF
 
 database: mongoid_test_s1
@@ -64,10 +64,10 @@ database: mongoid_test_s1
 EOF
 
       with_env("MONGOID_CLIENT_NAME" => "shard1") do
-        assert_output(output) { invoke("db:migrate:status") }
+        assert_output(output) { invoke("mongoid:migrate:status") }
       end
       with_env("VERSION" => "20210210125000") do
-        invoke("db:migrate:down")
+        invoke("mongoid:migrate:down")
       end
       output = <<-EOF
 
@@ -79,7 +79,7 @@ database: mongoid_test_s1
    up     20210210125532  ShardDatabaseMigrationTwo
 EOF
       with_env("MONGOID_CLIENT_NAME" => "shard1") do
-        assert_output(output) { invoke("db:migrate:status") }
+        assert_output(output) { invoke("mongoid:migrate:status") }
       end
       output = <<-EOF
 
@@ -90,7 +90,7 @@ database: mongoid_test
   down    20210210125000  DefaultDatabaseMigration
    up     20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("mongoid:migrate:status") }
         assert_equal(1, DataMigration.count)
       Mongoid::Migrator.with_mongoid_client("shard1") do
         assert_equal(2, DataMigration.count)
@@ -99,9 +99,9 @@ EOF
 
     def test_multidatabase_migrate_down_on_target_client
       Mongoid::Migrator.migrations_path = [MIGRATIONS_ROOT + "/multi_shards"]
-      invoke("db:migrate")
+      invoke("mongoid:migrate")
       with_env("MONGOID_CLIENT_NAME" => "shard1") do
-        invoke("db:migrate")
+        invoke("mongoid:migrate")
       end
 
       output = <<-EOF
@@ -113,7 +113,7 @@ database: mongoid_test
    up     20210210125000  DefaultDatabaseMigration
    up     20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("mongoid:migrate:status") }
       output = <<-EOF
 
 database: mongoid_test_s1
@@ -125,8 +125,8 @@ database: mongoid_test_s1
 EOF
 
       with_env("MONGOID_CLIENT_NAME" => "shard1", "VERSION" => "20210210124656") do
-        assert_output(output) { invoke("db:migrate:status") }
-        invoke("db:migrate:down")
+        assert_output(output) { invoke("mongoid:migrate:status") }
+        invoke("mongoid:migrate:down")
         output = <<-EOF
 
 database: mongoid_test_s1
@@ -136,7 +136,7 @@ database: mongoid_test_s1
   down    20210210124656  ShardDatabaseMigration
    up     20210210125532  ShardDatabaseMigrationTwo
 EOF
-        assert_output(output) { invoke("db:migrate:status") }
+        assert_output(output) { invoke("mongoid:migrate:status") }
       end
       output = <<-EOF
 
@@ -147,7 +147,7 @@ database: mongoid_test
    up     20210210125000  DefaultDatabaseMigration
    up     20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("mongoid:migrate:status") }
       assert_equal(2, DataMigration.count)
       Mongoid::Migrator.with_mongoid_client("shard1") do
         assert_equal(1, DataMigration.count)

--- a/test/tasks/drop_task_test.rb
+++ b/test/tasks/drop_task_test.rb
@@ -4,37 +4,37 @@ module Mongoid
   class DropTaskTest < TaskTestBase
     def test_drop_database
       Mongoid::Migrator.migrations_path = [MIGRATIONS_ROOT + "/valid"]
-      invoke("db:migrate")
-      assert_output("20100513063902\n") { invoke("db:version") }
-      invoke("db:drop")
-      assert_output("0\n") { invoke("db:version") }
+      invoke("mongoid:migrate")
+      assert_output("20100513063902\n") { invoke("mongoid:version") }
+      invoke("mongoid:drop")
+      assert_output("0\n") { invoke("mongoid:version") }
     end
 
     def test_drop_multidatabase
       Mongoid::Migrator.migrations_path = [MIGRATIONS_ROOT + "/multi_shards"]
-      invoke("db:migrate")
-      assert_output("20210210125800\n") { invoke("db:version") }
+      invoke("mongoid:migrate")
+      assert_output("20210210125800\n") { invoke("mongoid:version") }
       with_env("MONGOID_CLIENT_NAME" => "shard1") do
-        invoke("db:migrate")
-        assert_output("20210210125532\n") { invoke("db:version") }
+        invoke("mongoid:migrate")
+        assert_output("20210210125532\n") { invoke("mongoid:version") }
       end
-      invoke("db:drop")
-      assert_output("0\n") { invoke("db:version") }
-      with_env("MONGOID_CLIENT_NAME" => "shard1") { assert_output("20210210125532\n") { invoke("db:version") } }
+      invoke("mongoid:drop")
+      assert_output("0\n") { invoke("mongoid:version") }
+      with_env("MONGOID_CLIENT_NAME" => "shard1") { assert_output("20210210125532\n") { invoke("mongoid:version") } }
     end
 
 
     def test_drop_multidatabase_on_target_client
       Mongoid::Migrator.migrations_path = [MIGRATIONS_ROOT + "/multi_shards"]
-      invoke("db:migrate")
-      assert_output("20210210125800\n") { invoke("db:version") }
+      invoke("mongoid:migrate")
+      assert_output("20210210125800\n") { invoke("mongoid:version") }
       with_env("MONGOID_CLIENT_NAME" => "shard1") do
-        invoke("db:migrate")
-        assert_output("20210210125532\n") { invoke("db:version") }
-        invoke("db:drop")
-        assert_output("0\n") { invoke("db:version") }
+        invoke("mongoid:migrate")
+        assert_output("20210210125532\n") { invoke("mongoid:version") }
+        invoke("mongoid:drop")
+        assert_output("0\n") { invoke("mongoid:version") }
       end
-      assert_output("20210210125800\n") { invoke("db:version") }
+      assert_output("20210210125800\n") { invoke("mongoid:version") }
     end
   end
 end

--- a/test/tasks/migrate_task_test.rb
+++ b/test/tasks/migrate_task_test.rb
@@ -14,8 +14,8 @@ database: mongoid_test
   down    20100513055502  AddSecondSurveySchema
   down    20100513063902  AddImprovementPlanSurveySchema
 EOF
-      ) { invoke("db:migrate:status") }
-      invoke("db:migrate")
+      ) { invoke("mongoid:migrate:status") }
+      invoke("mongoid:migrate")
       assert_output(<<-EOF
 
 database: mongoid_test
@@ -26,7 +26,7 @@ database: mongoid_test
    up     20100513055502  AddSecondSurveySchema
    up     20100513063902  AddImprovementPlanSurveySchema
 EOF
-      ) { invoke("db:migrate:status") }
+      ) { invoke("mongoid:migrate:status") }
     end
 
     def test_database_migrate_with_version
@@ -41,8 +41,8 @@ database: mongoid_test
   down    20100513055502  AddSecondSurveySchema
   down    20100513063902  AddImprovementPlanSurveySchema
 EOF
-      ) { invoke("db:migrate:status") }
-      with_env("VERSION" => "20100513055502") { invoke("db:migrate") }
+      ) { invoke("mongoid:migrate:status") }
+      with_env("VERSION" => "20100513055502") { invoke("mongoid:migrate") }
       assert_output(<<-EOF
 
 database: mongoid_test
@@ -53,7 +53,7 @@ database: mongoid_test
    up     20100513055502  AddSecondSurveySchema
   down    20100513063902  AddImprovementPlanSurveySchema
 EOF
-      ) { invoke("db:migrate:status") }
+      ) { invoke("mongoid:migrate:status") }
     end
 
 
@@ -68,7 +68,7 @@ database: mongoid_test
   down    20210210125000  DefaultDatabaseMigration
   down    20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("mongoid:migrate:status") }
       output = <<-EOF
 
 database: mongoid_test_s1
@@ -79,9 +79,9 @@ database: mongoid_test_s1
   down    20210210125532  ShardDatabaseMigrationTwo
 EOF
 
-      invoke("db:migrate")
+      invoke("mongoid:migrate")
       with_env("MONGOID_CLIENT_NAME" => "shard1") do
-        assert_output(output) { invoke("db:migrate:status") }
+        assert_output(output) { invoke("mongoid:migrate:status") }
       end
       output = <<-EOF
 
@@ -92,7 +92,7 @@ database: mongoid_test
    up     20210210125000  DefaultDatabaseMigration
    up     20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("mongoid:migrate:status") }
       assert_equal(2, DataMigration.count)
       assert_equal(2, SurveySchema.count)
       Mongoid::Migrator.with_mongoid_client("shard1") do
@@ -112,7 +112,7 @@ database: mongoid_test
   down    20210210125000  DefaultDatabaseMigration
   down    20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("mongoid:migrate:status") }
       output = <<-EOF
 
 database: mongoid_test_s1
@@ -124,8 +124,8 @@ database: mongoid_test_s1
 EOF
 
       with_env("MONGOID_CLIENT_NAME" => "shard1") do
-        assert_output(output) { invoke("db:migrate:status") }
-        invoke("db:migrate")
+        assert_output(output) { invoke("mongoid:migrate:status") }
+        invoke("mongoid:migrate")
         output = <<-EOF
 
 database: mongoid_test_s1
@@ -135,7 +135,7 @@ database: mongoid_test_s1
    up     20210210124656  ShardDatabaseMigration
    up     20210210125532  ShardDatabaseMigrationTwo
 EOF
-        assert_output(output) { invoke("db:migrate:status") }
+        assert_output(output) { invoke("mongoid:migrate:status") }
       end
       output = <<-EOF
 
@@ -146,7 +146,7 @@ database: mongoid_test
   down    20210210125000  DefaultDatabaseMigration
   down    20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("mongoid:migrate:status") }
       assert_equal(0, DataMigration.count)
       Mongoid::Migrator.with_mongoid_client("shard1") do
         assert_equal(2, DataMigration.count)

--- a/test/tasks/redo_task_test.rb
+++ b/test/tasks/redo_task_test.rb
@@ -4,9 +4,9 @@ module Mongoid
   class RedoTaskTest < TaskTestBase
     def test_database_migrate_redo
       Mongoid::Migrator.migrations_path = [MIGRATIONS_ROOT + "/valid"]
-      invoke("db:migrate")
+      invoke("mongoid:migrate")
       with_env("VERSION" => "20100513055502") do
-        invoke("db:migrate:down")
+        invoke("mongoid:migrate:down")
       end
       assert_output(<<-EOF
 
@@ -18,8 +18,8 @@ database: mongoid_test
   down    20100513055502  AddSecondSurveySchema
    up     20100513063902  AddImprovementPlanSurveySchema
 EOF
-      ) { invoke("db:migrate:status") }
-      invoke("db:migrate:redo")
+      ) { invoke("mongoid:migrate:status") }
+      invoke("mongoid:migrate:redo")
       assert_output(<<-EOF
 
 database: mongoid_test
@@ -30,14 +30,14 @@ database: mongoid_test
    up     20100513055502  AddSecondSurveySchema
    up     20100513063902  AddImprovementPlanSurveySchema
 EOF
-      ) { invoke("db:migrate:status") }
+      ) { invoke("mongoid:migrate:status") }
     end
 
     def test_database_migrate_redo_version
       Mongoid::Migrator.migrations_path = [MIGRATIONS_ROOT + "/valid"]
-      invoke("db:migrate")
+      invoke("mongoid:migrate")
       with_env("VERSION" => "20100513063902") do
-        invoke("db:migrate:down")
+        invoke("mongoid:migrate:down")
       end
       assert_output(<<-EOF
 
@@ -49,8 +49,8 @@ database: mongoid_test
    up     20100513055502  AddSecondSurveySchema
   down    20100513063902  AddImprovementPlanSurveySchema
 EOF
-      ) { invoke("db:migrate:status") }
-      with_env("VERSION" => "20100513055502") { invoke("db:migrate:redo") }
+      ) { invoke("mongoid:migrate:status") }
+      with_env("VERSION" => "20100513055502") { invoke("mongoid:migrate:redo") }
       assert_output(<<-EOF
 
 database: mongoid_test
@@ -61,12 +61,12 @@ database: mongoid_test
    up     20100513055502  AddSecondSurveySchema
   down    20100513063902  AddImprovementPlanSurveySchema
 EOF
-      ) { invoke("db:migrate:status") }
+      ) { invoke("mongoid:migrate:status") }
     end
 
     def test_multidatabase_redo
       Mongoid::Migrator.migrations_path = [MIGRATIONS_ROOT + "/multi_shards"]
-      invoke("db:migrate")
+      invoke("mongoid:migrate")
       output = <<-EOF
 
 database: mongoid_test
@@ -76,7 +76,7 @@ database: mongoid_test
    up     20210210125000  DefaultDatabaseMigration
    up     20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("mongoid:migrate:status") }
       with_env("MONGOID_CLIENT_NAME" => "shard1") do
         assert_output(<<-EOF
 
@@ -87,9 +87,9 @@ database: mongoid_test_s1
   down    20210210124656  ShardDatabaseMigration
   down    20210210125532  ShardDatabaseMigrationTwo
 EOF
-        ) { invoke("db:migrate:status") }
+        ) { invoke("mongoid:migrate:status") }
       end
-      invoke("db:migrate:redo")
+      invoke("mongoid:migrate:redo")
       output = <<-EOF
 
 database: mongoid_test
@@ -99,7 +99,7 @@ database: mongoid_test
    up     20210210125000  DefaultDatabaseMigration
    up     20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("mongoid:migrate:status") }
       with_env("MONGOID_CLIENT_NAME" => "shard1") do
         assert_output(<<-EOF
 
@@ -110,7 +110,7 @@ database: mongoid_test_s1
   down    20210210124656  ShardDatabaseMigration
   down    20210210125532  ShardDatabaseMigrationTwo
 EOF
-        ) { invoke("db:migrate:status") }
+        ) { invoke("mongoid:migrate:status") }
       end
     end
 
@@ -125,9 +125,9 @@ database: mongoid_test
   down    20210210125000  DefaultDatabaseMigration
   down    20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("mongoid:migrate:status") }
       with_env("MONGOID_CLIENT_NAME" => "shard1") do
-        invoke("db:migrate")
+        invoke("mongoid:migrate")
         output = <<-EOF
 
 database: mongoid_test_s1
@@ -137,9 +137,9 @@ database: mongoid_test_s1
    up     20210210124656  ShardDatabaseMigration
    up     20210210125532  ShardDatabaseMigrationTwo
 EOF
-        assert_output(output) { invoke("db:migrate:status") }
-        invoke("db:migrate:redo")
-        assert_output(output) { invoke("db:migrate:status") }
+        assert_output(output) { invoke("mongoid:migrate:status") }
+        invoke("mongoid:migrate:redo")
+        assert_output(output) { invoke("mongoid:migrate:status") }
       end
       output = <<-EOF
 
@@ -150,7 +150,7 @@ database: mongoid_test
   down    20210210125000  DefaultDatabaseMigration
   down    20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("mongoid:migrate:status") }
     end
   end
 end

--- a/test/tasks/reset_task_test.rb
+++ b/test/tasks/reset_task_test.rb
@@ -4,9 +4,9 @@ module Mongoid
   class ResetTaskTest < TaskTestBase
     def test_database_migrate_reset
       Mongoid::Migrator.migrations_path = [MIGRATIONS_ROOT + "/valid"]
-      invoke("db:migrate")
+      invoke("mongoid:migrate")
       with_env("VERSION" => "20100513055502") do
-         invoke("db:migrate:down")
+         invoke("mongoid:migrate:down")
       end
       assert_output(<<-EOF
 
@@ -18,8 +18,8 @@ database: mongoid_test
   down    20100513055502  AddSecondSurveySchema
    up     20100513063902  AddImprovementPlanSurveySchema
 EOF
-      ) { invoke("db:migrate:status") }
-      invoke("db:migrate:reset")
+      ) { invoke("mongoid:migrate:status") }
+      invoke("mongoid:migrate:reset")
       assert_output(<<-EOF
 
 database: mongoid_test
@@ -30,12 +30,12 @@ database: mongoid_test
    up     20100513055502  AddSecondSurveySchema
    up     20100513063902  AddImprovementPlanSurveySchema
 EOF
-      ) { invoke("db:migrate:status") }
+      ) { invoke("mongoid:migrate:status") }
     end
 
     def test_multidatabase_migrate_reset
       Mongoid::Migrator.migrations_path = [MIGRATIONS_ROOT + "/multi_shards"]
-      invoke("db:migrate")
+      invoke("mongoid:migrate")
       output = <<-EOF
 
 database: mongoid_test
@@ -45,7 +45,7 @@ database: mongoid_test
    up     20210210125000  DefaultDatabaseMigration
    up     20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("mongoid:migrate:status") }
       with_env("MONGOID_CLIENT_NAME" => "shard1") do
         assert_output(<<-EOF
 
@@ -56,9 +56,9 @@ database: mongoid_test_s1
   down    20210210124656  ShardDatabaseMigration
   down    20210210125532  ShardDatabaseMigrationTwo
 EOF
-        ) { invoke("db:migrate:status") }
+        ) { invoke("mongoid:migrate:status") }
       end
-      invoke("db:migrate:reset")
+      invoke("mongoid:migrate:reset")
       output = <<-EOF
 
 database: mongoid_test
@@ -68,7 +68,7 @@ database: mongoid_test
    up     20210210125000  DefaultDatabaseMigration
    up     20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("mongoid:migrate:status") }
       with_env("MONGOID_CLIENT_NAME" => "shard1") do
         assert_output(<<-EOF
 
@@ -79,7 +79,7 @@ database: mongoid_test_s1
   down    20210210124656  ShardDatabaseMigration
   down    20210210125532  ShardDatabaseMigrationTwo
 EOF
-        ) { invoke("db:migrate:status") }
+        ) { invoke("mongoid:migrate:status") }
       end
     end
 
@@ -94,9 +94,9 @@ database: mongoid_test
   down    20210210125000  DefaultDatabaseMigration
   down    20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("mongoid:migrate:status") }
       with_env("MONGOID_CLIENT_NAME" => "shard1") do
-        invoke("db:migrate")
+        invoke("mongoid:migrate")
         output = <<-EOF
 
 database: mongoid_test_s1
@@ -106,9 +106,9 @@ database: mongoid_test_s1
    up     20210210124656  ShardDatabaseMigration
    up     20210210125532  ShardDatabaseMigrationTwo
 EOF
-        assert_output(output) { invoke("db:migrate:status") }
-        invoke("db:migrate:reset")
-        assert_output(output) { invoke("db:migrate:status") }
+        assert_output(output) { invoke("mongoid:migrate:status") }
+        invoke("mongoid:migrate:reset")
+        assert_output(output) { invoke("mongoid:migrate:status") }
       end
       output = <<-EOF
 
@@ -119,7 +119,7 @@ database: mongoid_test
   down    20210210125000  DefaultDatabaseMigration
   down    20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("mongoid:migrate:status") }
     end
   end
 end

--- a/test/tasks/rollback_test.rb
+++ b/test/tasks/rollback_test.rb
@@ -4,7 +4,7 @@ module Mongoid
   class RollbackTest < TaskTestBase
     def test_database_rollback
       Mongoid::Migrator.migrations_path = [MIGRATIONS_ROOT + "/valid"]
-      invoke("db:migrate")
+      invoke("mongoid:migrate")
       assert_output(<<-EOF
 
 database: mongoid_test
@@ -15,8 +15,8 @@ database: mongoid_test
    up     20100513055502  AddSecondSurveySchema
    up     20100513063902  AddImprovementPlanSurveySchema
 EOF
-      ) { invoke("db:migrate:status") }
-      invoke("db:rollback")
+      ) { invoke("mongoid:migrate:status") }
+      invoke("mongoid:rollback")
       assert_output(<<-EOF
 
 database: mongoid_test
@@ -27,12 +27,12 @@ database: mongoid_test
    up     20100513055502  AddSecondSurveySchema
   down    20100513063902  AddImprovementPlanSurveySchema
 EOF
-      ) { invoke("db:migrate:status") }
+      ) { invoke("mongoid:migrate:status") }
     end
 
     def test_database_rollback_step
       Mongoid::Migrator.migrations_path = [MIGRATIONS_ROOT + "/valid"]
-      invoke("db:migrate")
+      invoke("mongoid:migrate")
       assert_output(<<-EOF
 
 database: mongoid_test
@@ -43,8 +43,8 @@ database: mongoid_test
    up     20100513055502  AddSecondSurveySchema
    up     20100513063902  AddImprovementPlanSurveySchema
 EOF
-      ) { invoke("db:migrate:status") }
-      with_env("STEP" => "2") { invoke("db:rollback") }
+      ) { invoke("mongoid:migrate:status") }
+      with_env("STEP" => "2") { invoke("mongoid:rollback") }
       assert_output(<<-EOF
 
 database: mongoid_test
@@ -55,12 +55,12 @@ database: mongoid_test
   down    20100513055502  AddSecondSurveySchema
   down    20100513063902  AddImprovementPlanSurveySchema
 EOF
-      ) { invoke("db:migrate:status") }
+      ) { invoke("mongoid:migrate:status") }
     end
 
     def test_multidatabase_rollback
       Mongoid::Migrator.migrations_path = [MIGRATIONS_ROOT + "/multi_shards"]
-      invoke("db:migrate")
+      invoke("mongoid:migrate")
       output = <<-EOF
 
 database: mongoid_test
@@ -70,9 +70,9 @@ database: mongoid_test
    up     20210210125000  DefaultDatabaseMigration
    up     20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("mongoid:migrate:status") }
       with_env("MONGOID_CLIENT_NAME" => "shard1") do
-        invoke("db:migrate")
+        invoke("mongoid:migrate")
         assert_output(<<-EOF
 
 database: mongoid_test_s1
@@ -82,9 +82,9 @@ database: mongoid_test_s1
    up     20210210124656  ShardDatabaseMigration
    up     20210210125532  ShardDatabaseMigrationTwo
 EOF
-        ) { invoke("db:migrate:status") }
+        ) { invoke("mongoid:migrate:status") }
       end
-      invoke("db:rollback")
+      invoke("mongoid:rollback")
       output = <<-EOF
 
 database: mongoid_test
@@ -94,7 +94,7 @@ database: mongoid_test
    up     20210210125000  DefaultDatabaseMigration
   down    20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("mongoid:migrate:status") }
       with_env("MONGOID_CLIENT_NAME" => "shard1") do
         assert_output(<<-EOF
 
@@ -105,13 +105,13 @@ database: mongoid_test_s1
    up     20210210124656  ShardDatabaseMigration
    up     20210210125532  ShardDatabaseMigrationTwo
 EOF
-        ) { invoke("db:migrate:status") }
+        ) { invoke("mongoid:migrate:status") }
       end
     end
 
     def test_multidatabase_rollback_on_client_target
       Mongoid::Migrator.migrations_path = [MIGRATIONS_ROOT + "/multi_shards"]
-      invoke("db:migrate")
+      invoke("mongoid:migrate")
       output = <<-EOF
 
 database: mongoid_test
@@ -121,9 +121,9 @@ database: mongoid_test
    up     20210210125000  DefaultDatabaseMigration
    up     20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("mongoid:migrate:status") }
       with_env("MONGOID_CLIENT_NAME" => "shard1") do
-        invoke("db:migrate")
+        invoke("mongoid:migrate")
         output = <<-EOF
 
 database: mongoid_test_s1
@@ -133,8 +133,8 @@ database: mongoid_test_s1
    up     20210210124656  ShardDatabaseMigration
    up     20210210125532  ShardDatabaseMigrationTwo
 EOF
-        assert_output(output) { invoke("db:migrate:status") }
-        invoke("db:rollback")
+        assert_output(output) { invoke("mongoid:migrate:status") }
+        invoke("mongoid:rollback")
         output = <<-EOF
 
 database: mongoid_test_s1
@@ -144,7 +144,7 @@ database: mongoid_test_s1
    up     20210210124656  ShardDatabaseMigration
   down    20210210125532  ShardDatabaseMigrationTwo
 EOF
-        assert_output(output) { invoke("db:migrate:status") }
+        assert_output(output) { invoke("mongoid:migrate:status") }
       end
       output = <<-EOF
 
@@ -155,7 +155,7 @@ database: mongoid_test
    up     20210210125000  DefaultDatabaseMigration
    up     20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("mongoid:migrate:status") }
     end
   end
 end

--- a/test/tasks/rollback_to_test.rb
+++ b/test/tasks/rollback_to_test.rb
@@ -3,12 +3,12 @@ require_relative './task_test_base'
 module Mongoid
   class RollbackToTest < TaskTestBase
     def test_database_rollback_raise_without_version
-      assert_raises { invoke("db:rollback_to") }
+      assert_raises { invoke("mongoid:rollback_to") }
     end
 
     def test_database_rollback_to
       Mongoid::Migrator.migrations_path = [MIGRATIONS_ROOT + "/valid"]
-      invoke("db:migrate")
+      invoke("mongoid:migrate")
       assert_output(<<-EOF
 
 database: mongoid_test
@@ -19,8 +19,8 @@ database: mongoid_test
    up     20100513055502  AddSecondSurveySchema
    up     20100513063902  AddImprovementPlanSurveySchema
 EOF
-      ) { invoke("db:migrate:status") }
-      with_env("VERSION" => "20100513054656") { invoke("db:rollback_to") }
+      ) { invoke("mongoid:migrate:status") }
+      with_env("VERSION" => "20100513054656") { invoke("mongoid:rollback_to") }
       assert_output(<<-EOF
 
 database: mongoid_test
@@ -31,13 +31,13 @@ database: mongoid_test
   down    20100513055502  AddSecondSurveySchema
   down    20100513063902  AddImprovementPlanSurveySchema
 EOF
-      ) { invoke("db:migrate:status") }
+      ) { invoke("mongoid:migrate:status") }
     end
   end
 
   def test_multidatabase_rollback_to
     Mongoid::Migrator.migrations_path = [MIGRATIONS_ROOT + "/multi_shards"]
-    invoke("db:migrate")
+    invoke("mongoid:migrate")
     output = <<-EOF
 
 database: mongoid_test
@@ -47,9 +47,9 @@ Status   Migration ID    Migration Name
  up     20210210125000  DefaultDatabaseMigration
  up     20210210125800  DefaultDatabaseMigrationTwo
 EOF
-    assert_output(output) { invoke("db:migrate:status") }
+    assert_output(output) { invoke("mongoid:migrate:status") }
     with_env("MONGOID_CLIENT_NAME" => "shard1") do
-      invoke("db:migrate")
+      invoke("mongoid:migrate")
       assert_output(<<-EOF
 
 database: mongoid_test_s1
@@ -59,9 +59,9 @@ Status   Migration ID    Migration Name
  up     20210210124656  ShardDatabaseMigration
  up     20210210125532  ShardDatabaseMigrationTwo
 EOF
-      ) { invoke("db:migrate:status") }
+      ) { invoke("mongoid:migrate:status") }
     end
-    with_env("VERSION" => "20210210125000") { invoke("db:rollback_to") }
+    with_env("VERSION" => "20210210125000") { invoke("mongoid:rollback_to") }
     output = <<-EOF
 
 database: mongoid_test
@@ -71,7 +71,7 @@ Status   Migration ID    Migration Name
  up     20210210125000  DefaultDatabaseMigration
 down    20210210125800  DefaultDatabaseMigrationTwo
 EOF
-    assert_output(output) { invoke("db:migrate:status") }
+    assert_output(output) { invoke("mongoid:migrate:status") }
     with_env("MONGOID_CLIENT_NAME" => "shard1") do
       assert_output(<<-EOF
 
@@ -82,12 +82,12 @@ Status   Migration ID    Migration Name
  up     20210210124656  ShardDatabaseMigration
  up     20210210125532  ShardDatabaseMigrationTwo
 EOF
-      ) { invoke("db:migrate:status") }
+      ) { invoke("mongoid:migrate:status") }
     end
 
     def test_multidatabase_rollback_to_client_target
       Mongoid::Migrator.migrations_path = [MIGRATIONS_ROOT + "/multi_shards"]
-      invoke("db:migrate")
+      invoke("mongoid:migrate")
       output = <<-EOF
 
 database: mongoid_test
@@ -97,9 +97,9 @@ database: mongoid_test
    up     20210210125000  DefaultDatabaseMigration
    up     20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("mongoid:migrate:status") }
       with_env("MONGOID_CLIENT_NAME" => "shard1") do
-        invoke("db:migrate")
+        invoke("mongoid:migrate")
         output = <<-EOF
 
 database: mongoid_test_s1
@@ -109,8 +109,8 @@ database: mongoid_test_s1
    up     20210210124656  ShardDatabaseMigration
    up     20210210125532  ShardDatabaseMigrationTwo
 EOF
-        assert_output(output) { invoke("db:migrate:status") }
-        with_env("VERSION" => "20210210124656") { invoke("db:rollback_to") }
+        assert_output(output) { invoke("mongoid:migrate:status") }
+        with_env("VERSION" => "20210210124656") { invoke("mongoid:rollback_to") }
         output = <<-EOF
 
 database: mongoid_test_s1
@@ -120,7 +120,7 @@ database: mongoid_test_s1
    up     20210210124656  ShardDatabaseMigration
   down    20210210125532  ShardDatabaseMigrationTwo
 EOF
-        assert_output(output) { invoke("db:migrate:status") }
+        assert_output(output) { invoke("mongoid:migrate:status") }
       end
       output = <<-EOF
 
@@ -131,7 +131,7 @@ database: mongoid_test
    up     20210210125000  DefaultDatabaseMigration
    up     20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("mongoid:migrate:status") }
     end
   end
 end

--- a/test/tasks/status_task_test.rb
+++ b/test/tasks/status_task_test.rb
@@ -14,8 +14,8 @@ database: mongoid_test
   down    20100513055502  AddSecondSurveySchema
   down    20100513063902  AddImprovementPlanSurveySchema
 EOF
-      ) { invoke("db:migrate:status") }
-      invoke("db:migrate")
+      ) { invoke("mongoid:migrate:status") }
+      invoke("mongoid:migrate")
       assert_output(<<-EOF
 
 database: mongoid_test
@@ -26,7 +26,7 @@ database: mongoid_test
    up     20100513055502  AddSecondSurveySchema
    up     20100513063902  AddImprovementPlanSurveySchema
 EOF
-      ) { invoke("db:migrate:status") }
+      ) { invoke("mongoid:migrate:status") }
     end
 
     def test_multidatabase_migrate_status
@@ -40,8 +40,8 @@ database: mongoid_test
   down    20210210125000  DefaultDatabaseMigration
   down    20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
-      invoke("db:migrate")
+      assert_output(output) { invoke("mongoid:migrate:status") }
+      invoke("mongoid:migrate")
       output = <<-EOF
 
 database: mongoid_test
@@ -51,7 +51,7 @@ database: mongoid_test
    up     20210210125000  DefaultDatabaseMigration
    up     20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("mongoid:migrate:status") }
     end
 
     def test_multidatabase_migrate_status_in_target_client
@@ -66,8 +66,8 @@ database: mongoid_test_s1
   down    20210210124656  ShardDatabaseMigration
   down    20210210125532  ShardDatabaseMigrationTwo
 EOF
-        assert_output(output) { invoke("db:migrate:status") }
-        invoke("db:migrate")
+        assert_output(output) { invoke("mongoid:migrate:status") }
+        invoke("mongoid:migrate")
         output = <<-EOF
 
 database: mongoid_test_s1
@@ -77,7 +77,7 @@ database: mongoid_test_s1
    up     20210210124656  ShardDatabaseMigration
    up     20210210125532  ShardDatabaseMigrationTwo
 EOF
-        assert_output(output) { invoke("db:migrate:status") }
+        assert_output(output) { invoke("mongoid:migrate:status") }
       end
     end
   end

--- a/test/tasks/task_test_base.rb
+++ b/test/tasks/task_test_base.rb
@@ -5,14 +5,14 @@ load 'lib/mongoid_rails_migrations/mongoid_ext/railties/database.rake'
 module Mongoid
   class TaskTestBase < Minitest::Test #:nodoc:
     def setup
-      invoke("db:drop")
+      invoke("mongoid:drop")
       with_env("MONGOID_CLIENT_NAME" => "shard1") do
-        invoke("db:drop")
+        invoke("mongoid:drop")
       end
     end
 
     def teardown
-      Mongoid::Migrator.migrations_path = ["db/migrate"]
+      Mongoid::Migrator.migrations_path = ["db/mongoid/migrate"]
     end
   end
 end

--- a/test/tasks/up_task_test.rb
+++ b/test/tasks/up_task_test.rb
@@ -3,7 +3,7 @@ require_relative './task_test_base'
 module Mongoid
   class UpTaskTest < TaskTestBase
     def test_database_migrate_up_raise_without_version
-      assert_raises { invoke("db:migrate:up") }
+      assert_raises { invoke("mongoid:migrate:up") }
     end
 
     def test_database_migrate_up
@@ -18,9 +18,9 @@ database: mongoid_test
   down    20100513055502  AddSecondSurveySchema
   down    20100513063902  AddImprovementPlanSurveySchema
 EOF
-      ) { invoke("db:migrate:status") }
+      ) { invoke("mongoid:migrate:status") }
       with_env("VERSION" => "20100513055502") do
-        invoke("db:migrate:up")
+        invoke("mongoid:migrate:up")
       end
       assert_output(<<-EOF
 
@@ -32,7 +32,7 @@ database: mongoid_test
    up     20100513055502  AddSecondSurveySchema
   down    20100513063902  AddImprovementPlanSurveySchema
 EOF
-      ) { invoke("db:migrate:status") }
+      ) { invoke("mongoid:migrate:status") }
     end
 
 
@@ -47,7 +47,7 @@ database: mongoid_test
   down    20210210125000  DefaultDatabaseMigration
   down    20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("mongoid:migrate:status") }
       output = <<-EOF
 
 database: mongoid_test_s1
@@ -59,13 +59,13 @@ database: mongoid_test_s1
 EOF
 
       with_env("MONGOID_CLIENT_NAME" => "shard1") do
-        assert_output(output) { invoke("db:migrate:status") }
+        assert_output(output) { invoke("mongoid:migrate:status") }
       end
       with_env("VERSION" => "20210210125000") do
-        invoke("db:migrate:up")
+        invoke("mongoid:migrate:up")
       end
       with_env("MONGOID_CLIENT_NAME" => "shard1") do
-        assert_output(output) { invoke("db:migrate:status") }
+        assert_output(output) { invoke("mongoid:migrate:status") }
       end
       output = <<-EOF
 
@@ -76,7 +76,7 @@ database: mongoid_test
    up     20210210125000  DefaultDatabaseMigration
   down    20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("mongoid:migrate:status") }
         assert_equal(1, DataMigration.count)
         assert_equal(1, SurveySchema.count)
         Mongoid::Migrator.with_mongoid_client("shard1") do
@@ -97,7 +97,7 @@ database: mongoid_test
   down    20210210125000  DefaultDatabaseMigration
   down    20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("mongoid:migrate:status") }
       output = <<-EOF
 
 database: mongoid_test_s1
@@ -109,8 +109,8 @@ database: mongoid_test_s1
 EOF
 
       with_env("MONGOID_CLIENT_NAME" => "shard1", "VERSION" => "20210210124656") do
-        assert_output(output) { invoke("db:migrate:status") }
-        invoke("db:migrate:up")
+        assert_output(output) { invoke("mongoid:migrate:status") }
+        invoke("mongoid:migrate:up")
         output = <<-EOF
 
 database: mongoid_test_s1
@@ -120,7 +120,7 @@ database: mongoid_test_s1
    up     20210210124656  ShardDatabaseMigration
   down    20210210125532  ShardDatabaseMigrationTwo
 EOF
-        assert_output(output) { invoke("db:migrate:status") }
+        assert_output(output) { invoke("mongoid:migrate:status") }
       end
       output = <<-EOF
 
@@ -131,7 +131,7 @@ database: mongoid_test
   down    20210210125000  DefaultDatabaseMigration
   down    20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("mongoid:migrate:status") }
       assert_equal(0, DataMigration.count)
       Mongoid::Migrator.with_mongoid_client("shard1") do
         assert_equal(1, DataMigration.count)

--- a/test/tasks/version_task_test.rb
+++ b/test/tasks/version_task_test.rb
@@ -4,32 +4,32 @@ module Mongoid
   class VersionTaskTest < TaskTestBase
     def test_database_version
       Mongoid::Migrator.migrations_path = [MIGRATIONS_ROOT + "/valid"]
-      assert_output("0\n") { invoke("db:version") }
-      invoke("db:migrate")
-      assert_output("20100513063902\n") { invoke("db:version") }
-      invoke("db:drop")
-      assert_output("0\n") { invoke("db:version") }
+      assert_output("0\n") { invoke("mongoid:version") }
+      invoke("mongoid:migrate")
+      assert_output("20100513063902\n") { invoke("mongoid:version") }
+      invoke("mongoid:drop")
+      assert_output("0\n") { invoke("mongoid:version") }
     end
 
     def test_multidatabase_version
       Mongoid::Migrator.migrations_path = [MIGRATIONS_ROOT + "/multi_shards"]
-      assert_output("0\n") { invoke("db:version") }
-      invoke("db:migrate")
-      assert_output("20210210125800\n") { invoke("db:version") }
-      invoke("db:drop")
-      assert_output("0\n") { invoke("db:version") }
+      assert_output("0\n") { invoke("mongoid:version") }
+      invoke("mongoid:migrate")
+      assert_output("20210210125800\n") { invoke("mongoid:version") }
+      invoke("mongoid:drop")
+      assert_output("0\n") { invoke("mongoid:version") }
     end
 
     def test_multidatabase_version_with_target_client_and_rollback
       Mongoid::Migrator.migrations_path = [MIGRATIONS_ROOT + "/multi_shards"]
       with_env("MONGOID_CLIENT_NAME" => "shard1") do
-        assert_output("0\n") { invoke("db:version") }
-        invoke("db:migrate")
-        assert_output("20210210125532\n") { invoke("db:version") }
-        invoke("db:rollback")
-        assert_output("20210210124656\n") { invoke("db:version") }
-        invoke("db:rollback")
-        assert_output("0\n") { invoke("db:version") }
+        assert_output("0\n") { invoke("mongoid:version") }
+        invoke("mongoid:migrate")
+        assert_output("20210210125532\n") { invoke("mongoid:version") }
+        invoke("mongoid:rollback")
+        assert_output("20210210124656\n") { invoke("mongoid:version") }
+        invoke("mongoid:rollback")
+        assert_output("0\n") { invoke("mongoid:version") }
       end
     end
   end


### PR DESCRIPTION
## What
Re-applies uniiverse's fork customization on top of **upstream v1.6.2** (our previous fork was stuck on v1.1.0, whose task bodies use Mongoid-4 APIs — e.g. `Mongoid.master` — that break on Mongoid 7).

Two changes to `database.rake` + one defensive fix:
1. **Tasks move from the `db:` namespace → `mongoid:`.** Stock registers under `db:`; since Rake task defs are additive, that enhances ActiveRecord's `db:migrate` to *also* run the Mongoid migrator.
2. **Mongoid migrator runs against `db/mongoid/migrate/`** (not the default `db/migrate`), so it never touches the ActiveRecord migrations.
3. Guard the rescue against a `nil` `buffer_output` (upstream raises `NoMethodError` there, masking the real migration error).

## Why
On `web`, `make migrate` runs `rake db:migrate` (ActiveRecord, Postgres `schema_migrations`) + `rake mongoid:migrate` (Mongoid, Mongo `data_migrations`). With stock 1.6.2 the `db:` clobber made `rake db:migrate` re-run already-applied AR/Gila migrations through the Mongoid migrator, producing `PG::DuplicateTable: relation "cost_items" already exists` in production (Sentry WEB-12D0). This restores the separation the fork always provided.

## Compatibility
Upstream v1.6.2 base (tests Rails 8 / Mongoid 9 / Ruby 3.4 per its changelog); works on the web app's Ruby 2.6.8 / Mongoid 7.6.1 / Rails 5.2→6.1 stack.

## Verified
In a booted app container: `rake -W db:migrate` shows `db:migrate` defined **only** by ActiveRecord's railtie (no gem action), and `rake -T` shows `mongoid:migrate` (desc: "scripts in db/mongoid/migrate/") and the rest of the `mongoid:` tasks.

Related: [UNI-6162](https://universedev.atlassian.net/browse/UNI-6162)


[UNI-6162]: https://universedev.atlassian.net/browse/UNI-6162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ